### PR TITLE
Small Code Cleanup

### DIFF
--- a/src/mbc/mbc0.rs
+++ b/src/mbc/mbc0.rs
@@ -1,13 +1,15 @@
 
 pub fn read_mbc0(data: &[u8]) {
-    let mut title = String::from("");
     let len = match data[0x143] & 80 {
-        0x80    => 11,
-        _       => 16,
+        0x80 => 11,
+        _ => 16,
     };
-    for i in 0 .. len {
-        title.push(data[i + 0x134] as char)
-    };
+    let title = data[0x134..][..len]
+        .iter()
+        .cloned()
+        .map(|b| b as char)
+        .collect::<String>();
+
     println!("ROM Info:");
     println!("Title: {}", title);
     println!("CGB Flag: {}", data[0x143]);

--- a/src/mbc/mod.rs
+++ b/src/mbc/mod.rs
@@ -7,10 +7,9 @@ pub mod mbc0;
 
 pub fn read_mbc(filename: path::PathBuf) -> Result<String, Box<Error>> {
     let mut data = vec![];
-    try!(File::open(&filename)
-        .and_then(|mut f| f.read_to_end(&mut data))
-        .map_err(|_| "Could not read ROM"));
-    try!(validate_rom(&data));
+    File::open(&filename).and_then(|mut f| f.read_to_end(&mut data))
+        .map_err(|_| "Could not read ROM")?;
+    validate_rom(&data)?;
     match data[0x147] {
         0 => mbc0::read_mbc0(&data),
         _ => panic!("Unsupported MBC".to_string()),
@@ -18,19 +17,19 @@ pub fn read_mbc(filename: path::PathBuf) -> Result<String, Box<Error>> {
     Ok("Good".to_string())
 }
 
-pub fn validate_rom(data: &[u8]) -> Result<String, Box<Error>>  {
-    try!(check_header_checksum(data));
+pub fn validate_rom(data: &[u8]) -> Result<String, Box<Error>> {
+    check_header_checksum(data)?;
     Ok("Good".to_string())
 }
 
 pub fn check_header_checksum(data: &[u8]) -> Result<(), &'static str> {
     let mut value: u8 = 0;
-    for i in 0x134 .. 0x14D {
-        value = value.wrapping_sub(data[i]).wrapping_sub(1);
+    for &byte in &data[0x134..0x14D] {
+        value = value.wrapping_sub(byte).wrapping_sub(1);
     }
-    match data[0x14D] == value
-    {
-        true    => Ok(()),
-        false   => Err("Invalid cartridge checksum"),
+    if data[0x14D] == value {
+        Ok(())
+    } else {
+        Err("Invalid cartridge checksum")
     }
 }

--- a/src/z80/ops/add.rs
+++ b/src/z80/ops/add.rs
@@ -1,15 +1,14 @@
 use z80::Z80;
 
-//Need to check for overflow, not sure if there's a better way to check
 pub fn add_r_e(z80: &mut Z80) {
-    let temp: u16 = z80.r.a as u16 + z80.r.e as u16;
+    let (sum, overflow) = z80.r.a.overflowing_add(z80.r.e);
     z80.r.f = 0;
-    if (temp & 255 as u16) != 0 {
+    if sum != 0 {
         z80.r.f |= 0x80;
     }
-    if temp > 255 {
+    if overflow {
         z80.r.f |= 0x10;
     }
-    z80.r.a = temp as u8 & 255;
+    z80.r.a = sum;
     z80.set_register_clock(1);
 }


### PR DESCRIPTION
- Prevent manual indexing and use iterators instead
- Question mark operator instead of try-macro
- Overlowing add for the add_r_e function